### PR TITLE
Prevent error if saving a record which hasn't changed

### DIFF
--- a/monom/mongo.py
+++ b/monom/mongo.py
@@ -247,6 +247,8 @@ class MongoModel(BaseModel, metaclass=MongoModelType):
             else:
                 modified, deleted = self._combine_tracked_fields()
                 update = {}
+                if not modified | deleted:
+                    return self
                 if modified:
                     update['$set'] = {field: get_dict_item_with_dot(doc, field) for field in modified}
                 if deleted:
@@ -277,6 +279,8 @@ class MongoModel(BaseModel, metaclass=MongoModelType):
                     continue
                 modified, deleted = obj._combine_tracked_fields()
                 update = {}
+                if not modified | deleted:
+                    continue
                 if modified:
                     update['$set'] = {field: get_dict_item_with_dot(doc, field) for field in modified}
                 if deleted:


### PR DESCRIPTION
Test created to detect this.

**Before:**
```
   def test_save_no_changes(self, db):
        Post.set_db(db)
        post = Post(tags=['life', 'art']).save()
>       post.save()

test_mongo.py:119: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../monom/mongo.py:256: in save
    collection.update_one({'_id': self.pk}, update, **kw)
../venv/lib/python3.8/site-packages/pymongo/collection.py:993: in update_one
    common.validate_ok_for_update(update)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

update = {}

    def validate_ok_for_update(update):
        """Validate an update document."""
        validate_list_or_mapping("update", update)
        # Update cannot be {}.
        if not update:
>           raise ValueError('update cannot be empty')
E           ValueError: update cannot be empty

../venv/lib/python3.8/site-packages/pymongo/common.py:530: ValueError
```